### PR TITLE
Adding missing test lane and dependencies

### DIFF
--- a/fastlane-plugin-xml_editor.gemspec
+++ b/fastlane-plugin-xml_editor.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |spec|
   # Don't add a dependency to fastlane or fastlane_re
   # since this would cause a circular dependency
 
-  # spec.add_dependency 'your-dependency', '~> 1.0.0'
+  spec.add_dependency 'plist', '~> 3.3.0'
+  spec.add_dependency 'nokogiri', '~> 1.8.0'
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,3 +1,5 @@
 lane :test do
-  xml_editor
+  testFile = 'fastlane/test.xml'
+  xml_editor(path_to_xml_file: testFile, xml_path: '//document//string', new_value: 'World')
+  xml_editor(path_to_xml_file: testFile, xml_path: '//document//string/@attr', new_value: 'Hello')
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,0 +1,42 @@
+fastlane documentation
+================
+# Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
+```
+xcode-select --install
+```
+
+## Choose your installation method:
+
+<table width="100%" >
+<tr>
+<th width="33%"><a href="http://brew.sh">Homebrew</a></td>
+<th width="33%">Installer Script</td>
+<th width="33%">Rubygems</td>
+</tr>
+<tr>
+<td width="33%" align="center">macOS</td>
+<td width="33%" align="center">macOS</td>
+<td width="33%" align="center">macOS or Linux with Ruby 2.0.0 or above</td>
+</tr>
+<tr>
+<td width="33%"><code>brew cask install fastlane</code></td>
+<td width="33%"><a href="https://download.fastlane.tools">Download the zip file</a>. Then double click on the <code>install</code> script (or run it in a terminal window).</td>
+<td width="33%"><code>sudo gem install fastlane -NV</code></td>
+</tr>
+</table>
+
+# Available Actions
+### test
+```
+fastlane test
+```
+
+
+----
+
+This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
+More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
+The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/fastlane/report.xml
+++ b/fastlane/report.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="fastlane.lanes">
+    
+    
+    
+      
+      <testcase classname="fastlane.lanes" name="0: xml_editor" time="0.303109">
+        
+      </testcase>
+    
+      
+      <testcase classname="fastlane.lanes" name="1: xml_editor" time="0.01069">
+        
+      </testcase>
+    
+  </testsuite>
+</testsuites>

--- a/fastlane/test.xml
+++ b/fastlane/test.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document>
+  <string attr=""/>
+</document>


### PR DESCRIPTION
I've tried to use your plugin and found out two issues: 
 - Dependency gems were not on gemspec (plist and  nokogiri)
 - There was no actual working test lane, I just added a small test with attribute and value cases. 

Fixes #2 and #3 